### PR TITLE
[run] strip PS1 from env

### DIFF
--- a/simdb/run.py
+++ b/simdb/run.py
@@ -42,6 +42,9 @@ import yaml
 from simdb.db import DataLoader
 
 
+STRIP_FROM_ENV = ['PS1',]
+
+
 # Customize YAML serialization
 import numpy as np
 def ndarray_representer(dumper, data):
@@ -117,12 +120,16 @@ def _initialize():
         os.mkdir(os.path.join(db_path, 'RUNS'))
     uid = _make_uid(os.path.join(db_path, 'RUNS'))
     os.mkdir(os.path.join(db_path, 'RUNS', uid))
+    env = dict(os.environ)
+    for kk in STRIP_FROM_ENV:
+        if env.has_key(kk):
+            env.pop(kk)
     yaml.dump(dict(script=script,
                    argv=argv,
                    host=host,
                    git=git_info,
                    started=started,
-                   environment=dict(os.environ)),
+                   environment=env),
               open(os.path.join(db_path, 'RUNS', uid, 'INFO'), 'w'),
               allow_unicode=True)
     with open(os.path.join(db_path, 'RUNS', uid, 'SCRIPT'), 'w') as f:


### PR DESCRIPTION
I get strange conversion errors deep within yaml upon calling `new_dataset` that I could trace back to  yaml trying to parse the `PS1` in my env. This was the `PS1` in question:
```bash
\\[\x1b[1;${SEPCOLOR}m\\]\\\n\xe2\x94\x90 (\\[\x1b[1;${MAINCOLOR}m\\]\\u\\[\x1b[1;${SEPCOLOR}m\\]@\\[\x1b[0;${MAINCOLOR}m\\]\\h\\[\x1b[1;${SEPCOLOR}m\\]) [\\[\x1b[1;${MAINCOLOR}m\\]\\t\x1b[0;${MAINCOLOR}m\x1b[6D:\x1b[2C:\x1b[2C\\[\x1b[1;${SEPCOLOR}m\\]|\\[\x1b[0;${MAINCOLOR}m\\]\\d\\[\x1b[1;${SEPCOLOR}m\\]] $(__git_ps1 "[\\[\x1b[0;${MAINCOLOR}m\\]%s\\[\x1b[1;${SEPCOLOR}m\\]]") [\\[\x1b[0;${MAINCOLOR}m\\]`_bashish_prompt_cwd "\\[\x1b[1;${SEPCOLOR}m\\]" "\\[\x1b[0;${MAINCOLOR}m\\]" 58`\\[\x1b[1;${SEPCOLOR}m\\]] \\[\x1b[1;${SEPCOLOR}m\\]\n\xe2\x94\x94\\[\x1b[0;${MAINCOLOR}m\\]\xe2\x94\x80\xe2\x94\x80\\[\x1b[1;${MAINCOLOR}m\\]\xe2\x94\x80\\[\x1b[1;${MAINCOLOR}m\\]>\\[\x1b[0m\\] 
```
Since the `PS1` may contain strange formatting characters and probably does not add much information anyway, I propose to not record it.